### PR TITLE
Add padding and title styling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Options which are marked with an asterisk are required for that section.
   * `command: string`* The command to run
   * `rules: list` A comma separated list of the section names denoting
     rules to apply
+  * `title_attr: string` Name of the section defining the attributes of the title
+  * `padding: int | int,int | int,int,int,int` Padding around command output. Either one value for all sides, x value followed by y value or top, right, bottom and left values
   * `element...: Element` Element options
 * `Panel` A 1D arrangement of elements
   * `vertical: bool` If true, subpanels are stacked vertically

--- a/src/minimux/__init__.py
+++ b/src/minimux/__init__.py
@@ -166,7 +166,8 @@ class MiniMux:
         if command.title is not None:
             stdscr.move(range_y[0], range_x[0])
             stdscr.addstr(
-                command.title.center(range_x[1] - range_x[0]), command.attr(self.cm)
+                command.title.center(range_x[1] - range_x[0]),
+                command.title_attr(self.cm),
             )
             range_y = (range_y[0] + 1, range_y[1])
         self.runners[command.name].init(

--- a/src/minimux/runner.py
+++ b/src/minimux/runner.py
@@ -32,7 +32,11 @@ class Runner:
                 del self.win
             self.win = stdscr.subwin(*bounds)
             self.win.bkgdset(" ", self.bkgd)
-            self.buf.resize(maxrows=bounds[0], maxcols=bounds[1])
+            pt, pr, pb, pl = self.command.padding
+            self.buf.resize(
+                maxrows=bounds[0] - pt - pb,
+                maxcols=bounds[1] - pl - pr,
+            )
         self.flush()
 
     def start(self):
@@ -87,7 +91,10 @@ class Runner:
                 return
             self.win.clear()
             for i, (line, attr) in enumerate(self.buf):
-                self.win.move(i, 0)
+                self.win.move(
+                    i + self.command.padding[0],
+                    self.command.padding[3],
+                )
                 self.win.addstr(line, attr)
             self.win.refresh()
             curses.doupdate()


### PR DESCRIPTION
Adds two more options to the command section:
* `padding` which specifies space around the command output
* `title_attr` which defines a section which contains attributes to apply to the title of the section