### PR TITLE
Fix version flag

### DIFF
--- a/src/minimux/__main__.py
+++ b/src/minimux/__main__.py
@@ -7,7 +7,7 @@ from minimux.config import Config, MiniMuxConfigParser
 
 
 @click.command("minimux")
-@click.option("--version", "-v", is_flag=True)
+@click.version_option(__version__, "--version", "-v")
 @click.argument(
     "config_file",
     type=click.Path(
@@ -15,11 +15,9 @@ from minimux.config import Config, MiniMuxConfigParser
         dir_okay=False,
         path_type=Path,
     ),
+    default=Path("./minimux.ini"),
 )
-def main(config_file: Path, version: bool):
-    if version:
-        print(__version__)
-        exit(0)
+def main(config_file: Path):
     # load config
     parser = MiniMuxConfigParser()
     with open(config_file) as f:


### PR DESCRIPTION
The `--version` flag was broken, this fixes it by using `click.version_option`.

Also defaults to `minimux.ini` for the `CONFIG_FILE` if not provided